### PR TITLE
Fix Windows crash: guard POSIX dup() call in app()

### DIFF
--- a/src/app.jl
+++ b/src/app.jl
@@ -962,8 +962,12 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
     # stdin Julia object would read from the wrong source.
     _saved_input = INPUT_IO[] === nothing
     if _saved_input
-        saved_fd = ccall(:dup, Cint, (Cint,), Cint(0))
-        INPUT_IO[] = Base.TTY(RawFD(saved_fd))
+        @static if Sys.iswindows()
+            INPUT_IO[] = stdin
+        else
+            saved_fd = ccall(:dup, Cint, (Cint,), Cint(0))
+            INPUT_IO[] = Base.TTY(RawFD(saved_fd))
+        end
     end
     _restarting = Ref(false)
     with_terminal(; on_stdout, on_stderr, tty_out, tty_size) do t


### PR DESCRIPTION
## Summary
- Guard the `ccall(:dup, ...)` in `app()` with `@static if Sys.iswindows()`, falling back to `stdin` directly
- `dup` is POSIX-only and crashes immediately on Windows with "could not load symbol"
- The `dup` is only needed to preserve the real terminal fd before REPLWidget redirects stdin, but REPLWidget requires PTY and can't run on Windows anyway

## Test plan
- [x] All 4085 tests pass on macOS/Linux
- [ ] Verify demos launch on Windows 11 + Julia 1.12.5

Fixes #11