### PR TITLE
Fix error swallowing when app() runs in a spawned thread

### DIFF
--- a/src/app.jl
+++ b/src/app.jl
@@ -1005,6 +1005,8 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
         end
     end
     _restarting = Ref(false)
+    _app_error = Ref{Any}(nothing)
+    _app_bt = Ref{Any}(nothing)
     with_terminal(; on_stdout, on_stderr, tty_out, tty_size) do t
         init!(model, t)
         _load_layout_prefs!(model)
@@ -1134,6 +1136,9 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
                     overlay.notify_ttl = typemax(Int)
                 end
             end
+        catch e
+            _app_error[] = e
+            _app_bt[] = catch_backtrace()
         finally
             close(frame_timer)
             close(wake)  # unblocks stdin_monitor + any pending take!
@@ -1146,5 +1151,10 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
     # (leave_tui!, raw mode off, alt screen off) before app teardown begins.
     cleanup!(model)
     _saved_input && (INPUT_IO[] = nothing)
+    if _app_error[] !== nothing
+        Base.showerror(stderr, _app_error[], _app_bt[])
+        println(stderr)
+        throw(_app_error[])
+    end
     _restarting[] ? :restart : nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,4 +33,5 @@ struct _DummyModel <: T.Model end
     include("test_terminal_widget.jl")
     include("test_paged_datatable.jl")
     include("test_ansitext.jl")
+    include("test_app_error.jl")
 end

--- a/test/test_app_error.jl
+++ b/test/test_app_error.jl
@@ -1,0 +1,74 @@
+@testset "app() error propagation (#20)" begin
+    # Model whose view always throws
+    mutable struct _ErrorModel <: T.Model
+        quit::Bool
+        cleanup_called::Bool
+    end
+    _ErrorModel() = _ErrorModel(false, false)
+    T.should_quit(m::_ErrorModel) = m.quit
+    function T.view(m::_ErrorModel, f::T.Frame)
+        error("intentional view error for testing")
+    end
+    T.cleanup!(m::_ErrorModel) = (m.cleanup_called = true)
+
+    @testset "error in view surfaces from spawned task" begin
+        m = _ErrorModel()
+        # Set INPUT_IO to a BufferStream so app() skips the dup(0) call
+        # and the stdin monitor has something to wait on.
+        fake_input = Base.BufferStream()
+        old_input = T.INPUT_IO[]
+        T.INPUT_IO[] = fake_input
+        try
+            task = @async app(m; fps=60, default_bindings=false,
+                              tty_out="/dev/null", tty_size=(rows=24, cols=80))
+            # Wait for the task to finish (should fail quickly)
+            result = timedwait(() -> istaskdone(task), 10.0)
+            @test result == :ok  # task completed within timeout
+            @test istaskfailed(task)
+            # The thrown error should be an ErrorException with our message
+            err = task.result
+            @test err isa TaskFailedException || err isa ErrorException
+            if err isa TaskFailedException
+                @test occursin("intentional view error", sprint(showerror, err))
+            else
+                @test occursin("intentional view error", err.msg)
+            end
+            # cleanup! should still have been called despite the error
+            @test m.cleanup_called
+        finally
+            close(fake_input)
+            T.INPUT_IO[] = old_input
+        end
+    end
+
+    # Model that quits normally — sanity check that non-error path still works
+    mutable struct _QuitModel <: T.Model
+        frames::Int
+        cleanup_called::Bool
+    end
+    _QuitModel() = _QuitModel(0, false)
+    T.should_quit(m::_QuitModel) = m.frames >= 3
+    function T.view(m::_QuitModel, f::T.Frame)
+        m.frames += 1
+    end
+    T.cleanup!(m::_QuitModel) = (m.cleanup_called = true)
+
+    @testset "normal quit still works" begin
+        m = _QuitModel()
+        fake_input = Base.BufferStream()
+        old_input = T.INPUT_IO[]
+        T.INPUT_IO[] = fake_input
+        try
+            task = @async app(m; fps=60, default_bindings=false,
+                              tty_out="/dev/null", tty_size=(rows=24, cols=80))
+            result = timedwait(() -> istaskdone(task), 10.0)
+            @test result == :ok
+            @test !istaskfailed(task)
+            @test m.cleanup_called
+            @test m.frames >= 3
+        finally
+            close(fake_input)
+            T.INPUT_IO[] = old_input
+        end
+    end
+end


### PR DESCRIPTION
Closes #20.

## Summary

- Errors in `view`/`update!` were silently lost when `app()` ran inside `Threads.@spawn` — the TUI would open and disappear without showing the error
- Now `app()` catches exceptions from the event loop, ensures `cleanup!(model)` still runs, prints the error + backtrace to stderr after terminal restoration, and re-throws so `fetch`/`wait` surfaces it too

## Test plan

- [x] New test `test_app_error.jl` confirms error propagation from `view` in a spawned task
- [x] Test verified to **fail** without the fix (cleanup skipped) and **pass** with it
- [x] Normal quit path still works (sanity check test)
- [x] Full test suite: 4174 passed, 2 pre-existing failures unrelated to this change

@ronisbr — this should fix the issue you reported. You can test against this branch before it's merged:

```julia
using Pkg
Pkg.add(url="https://github.com/kahliburke/Tachikoma.jl", rev="fix/20-app-error-propagation")
```