### PR TITLE
Add missing function `value` for TabBar

### DIFF
--- a/src/widgets/tabs.jl
+++ b/src/widgets/tabs.jl
@@ -84,3 +84,5 @@ function render(bar::TabBar, rect::Rect, buf::Buffer)
         end
     end
 end
+
+value(bar::TabBar) = bar.active

--- a/test/test_widgets_coverage.jl
+++ b/test/test_widgets_coverage.jl
@@ -513,6 +513,11 @@
         @test occursin("Plain", row)
     end
 
+    @testset "TabBar: value" begin
+        tabs = T.TabBar(["A", "B"]; active=2)
+        @test T.value(tabs) == 2
+    end
+
     # ─────────────────────────────────────────────────────────────────
     # Scrollbar
     # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Hi @kahliburke !

The function `value` for TabBar is mentioned in the docs (https://kahliburke.github.io/Tachikoma.jl/dev/widgets#TabBar) but it was not implemented. This PR adds the function and test.