### PR TITLE
Fix syntax tabbar_demo

### DIFF
--- a/demos/TachikomaDemos/src/tabbar_demo.jl
+++ b/demos/TachikomaDemos/src/tabbar_demo.jl
@@ -81,7 +81,6 @@ end
 function update!(m::TabBarDemoModel, evt::MouseEvent)
     handle_mouse!(m.tabs, evt)
 end
-end
 
 function view(m::TabBarDemoModel, f::Frame)
     m.tick += 1


### PR DESCRIPTION
Hello,

first and foremost thank you for this great package.

Currently demos are broken since there is an additional `end` in the `tabbar_demo.jl` file. This small patch fixed that.