### PR TITLE
Usability improvements for TreeView

### DIFF
--- a/demos/TachikomaDemos/src/TachikomaDemos.jl
+++ b/demos/TachikomaDemos/src/TachikomaDemos.jl
@@ -46,6 +46,7 @@ include("colortypes_demo.jl")
 include("unicode_demo.jl")
 include("scroll_demo.jl")
 include("launcher.jl")
+include("simple_tree_demo.jl")
 
 export demo, rain, dashboard, life, snake, clock, waves, chaos,
        sysmon, anim_demo, mouse_demo, dotwave,
@@ -55,6 +56,6 @@ export demo, rain, dashboard, life, snake, clock, waves, chaos,
        fps_demo, phylo_demo, clado_demo, sixel_demo, sixel_gallery,
        async_demo, markdown_demo, windows_demo, terminal_demo, repl_demo,
        ansi_demo, tabbar_demo, widget_styles_demo, colortypes_demo,
-       unicode_demo, scroll_demo, launcher
+       unicode_demo, scroll_demo, launcher, simple_tree_demo
 
 end

--- a/demos/TachikomaDemos/src/launcher.jl
+++ b/demos/TachikomaDemos/src/launcher.jl
@@ -167,6 +167,9 @@ const DEMO_ENTRIES = DemoEntry[
     DemoEntry("Widget Scroll", :widget,
         "2D pannable viewport filled with widgets: sparklines, tables, bar charts, gauges, calendars. Click-drag to pan, scroll wheel, arrow keys, Home to reset.",
         () -> scroll_demo()),
+    DemoEntry("Tree View", :widget,
+        "Hierarchical TreeView with keyboard/mouse navigation. Live debug panel shows value(), selected_node(), and per-node user data via TreeNode.content.",
+        () -> simple_tree_demo()),
 
     # ── Data ──
     DemoEntry("DataTable", :data,

--- a/demos/TachikomaDemos/src/simple_tree_demo.jl
+++ b/demos/TachikomaDemos/src/simple_tree_demo.jl
@@ -1,0 +1,67 @@
+# ═══════════════════════════════════════════════════════════════════════
+# Simple Tree Demo ── debug of TreeView, displaying node info and row
+# 
+# arrow keys to navigate, [q] quit
+# ═══════════════════════════════════════════════════════════════════════
+
+using Base: @kwdef
+
+
+function build_tree()
+    root = TreeNode("System", 
+        [
+            TreeNode("Component", 
+                [TreeNode("thing"), TreeNode("A"), TreeNode("C")]
+            ), 
+            TreeNode("Component", 
+                [TreeNode("thing"), TreeNode("B"), TreeNode("D")]
+            ), 
+            TreeNode("Another component", 
+                [TreeNode("thing"), TreeNode("E")]
+            )
+        ]
+    )
+    return TreeView(root; indent=4, connector_style=tstyle(:border, dim=true), show_root=false)
+end
+
+@kwdef mutable struct TreeState <: Model
+    quit::Bool = false
+    do_modal::Bool = false
+    tick::UInt = 0
+    file::String = default_fsource
+    counter::UInt64 = 0
+    tree::TreeView = build_tree()
+    outer_layout::ResizableLayout = ResizableLayout(Horizontal, [Fixed(30), Fill()])
+end
+
+should_quit(m::TreeState) = m.quit
+
+function update!(m::TreeState, event::KeyEvent)
+    if event.key == :char && event.char == 'q'
+        m.quit = true
+        return
+    end
+    handle_key!(m.tree, event)
+end
+
+function update!(m::TreeState, event::MouseEvent)
+    handle_mouse!(m.tree, event)
+end
+
+function view(m::TreeState, f::Frame)
+    m.tick += 1
+    rects = split_layout(m.outer_layout, f.area)
+
+    innerL = render(Block(title="Tree", box=BOX_PLAIN), rects[1], f.buffer)
+    innerR = render(Block(title="Debug", box=BOX_PLAIN), rects[2], f.buffer)
+
+    spn = Paragraph("value: $(value(m.tree))\nvalue_node: $(Tachikoma.value_node(m.tree))", wrap=char_wrap)
+
+    render(m.tree, innerL, f.buffer)
+    render(spn, innerR, f.buffer)
+end
+
+function simple_tree_demo(; theme_name=nothing)
+    theme_name !== nothing && set_theme!(theme_name)
+    return app(TreeState(); fps=30)
+end

--- a/demos/TachikomaDemos/src/simple_tree_demo.jl
+++ b/demos/TachikomaDemos/src/simple_tree_demo.jl
@@ -54,7 +54,7 @@ function view(m::TreeState, f::Frame)
     innerL = render(Block(title="Tree", box=BOX_PLAIN), rects[1], f.buffer)
     innerR = render(Block(title="Debug", box=BOX_PLAIN), rects[2], f.buffer)
 
-    node_selection = Tachikoma.selected_node(m.tree)
+    node_selection = selected_node(m.tree)
     content_selection = isnothing(node_selection) ? nothing : node_selection.content
     spn = Paragraph("value: $(value(m.tree))\n\nselected node: $(node_selection)\n\nnode content: $(content_selection)", wrap=char_wrap)
 

--- a/demos/TachikomaDemos/src/simple_tree_demo.jl
+++ b/demos/TachikomaDemos/src/simple_tree_demo.jl
@@ -11,13 +11,13 @@ function build_tree()
     root = TreeNode("System", 
         [
             TreeNode("Component", 
-                [TreeNode("thing"), TreeNode("A"), TreeNode("C")]
+                [TreeNode("thing"), TreeNode("A"; content=0x32ab), TreeNode("C"; content="content of C")]
             ), 
             TreeNode("Component", 
-                [TreeNode("thing"), TreeNode("B"), TreeNode("D")]
+                [TreeNode("thing"; content="A string of content!"), TreeNode("B"), TreeNode("D"; content="content of D")]
             ), 
             TreeNode("Another component", 
-                [TreeNode("thing"), TreeNode("E")]
+                [TreeNode("thing"; content=-3.4e4), TreeNode("E"; content=Dict("a"=>1,"b"=>2, "c"=>3))]
             )
         ]
     )
@@ -28,7 +28,6 @@ end
     quit::Bool = false
     do_modal::Bool = false
     tick::UInt = 0
-    file::String = default_fsource
     counter::UInt64 = 0
     tree::TreeView = build_tree()
     outer_layout::ResizableLayout = ResizableLayout(Horizontal, [Fixed(30), Fill()])
@@ -55,7 +54,9 @@ function view(m::TreeState, f::Frame)
     innerL = render(Block(title="Tree", box=BOX_PLAIN), rects[1], f.buffer)
     innerR = render(Block(title="Debug", box=BOX_PLAIN), rects[2], f.buffer)
 
-    spn = Paragraph("value: $(value(m.tree))\nvalue_node: $(Tachikoma.value_node(m.tree))", wrap=char_wrap)
+    node_selection = Tachikoma.selected_node(m.tree)
+    content_selection = isnothing(node_selection) ? nothing : node_selection.content
+    spn = Paragraph("value: $(value(m.tree))\n\nselected node: $(node_selection)\n\nnode content: $(content_selection)", wrap=char_wrap)
 
     render(m.tree, innerL, f.buffer)
     render(spn, innerR, f.buffer)

--- a/docs/src/widgets.md
+++ b/docs/src/widgets.md
@@ -453,7 +453,7 @@ Optionally store user data in TreeNodes (`TreeNode.content` will default to `not
 <!-- tachi:noeval -->
 ```julia
 root = TreeNode("Root", [
-    TreeNode("Child 1", [TreeNode("Leaf A"); content="Leaf A content"]; content=("Child 1 content", 1e-4, true))])
+    TreeNode("Child 1", [TreeNode("Leaf A"; content="Leaf A content")]; content=("Child 1 content", 1e-4, true))])
 ```
 
 ### TabBar

--- a/docs/src/widgets.md
+++ b/docs/src/widgets.md
@@ -445,6 +445,15 @@ render(tree, area, buf)
 <!-- tachi:noeval -->
 ```julia
 handle_key!(tree, evt)     # up/down navigate, enter expand/collapse
+selected_node(tree)        # get TreeNode selection
+```
+
+Optionally store user data in TreeNodes (`TreeNode.content` will default to `nothing`):
+
+<!-- tachi:noeval -->
+```julia
+root = TreeNode("Root", [
+    TreeNode("Child 1", [TreeNode("Leaf A"); content="Leaf A content"]; content=("Child 1 content", 1e-4, true))])
 ```
 
 ### TabBar

--- a/src/Tachikoma.jl
+++ b/src/Tachikoma.jl
@@ -118,7 +118,7 @@ export # Core types
        # Widget protocol
        intrinsic_size, focusable, FocusRing, Container, WidgetScroll,
        next!, prev!, current, handle_key!,
-       value, set_value!, valid,
+       value, value_node, set_value!, valid,
        # Widgets
        BigText,
        Gauge, Sparkline, BarChart, BarEntry, Table,

--- a/src/Tachikoma.jl
+++ b/src/Tachikoma.jl
@@ -118,7 +118,7 @@ export # Core types
        # Widget protocol
        intrinsic_size, focusable, FocusRing, Container, WidgetScroll,
        next!, prev!, current, handle_key!,
-       value, value_node, set_value!, valid,
+       value, set_value!, valid,
        # Widgets
        BigText,
        Gauge, Sparkline, BarChart, BarEntry, Table,
@@ -131,7 +131,7 @@ export # Core types
        Modal, Paragraph, WrapMode, no_wrap, word_wrap, char_wrap,
        Alignment, align_left, align_center, align_right,
        paragraph_line_count,
-       TreeView, TreeNode,
+       TreeView, TreeNode, selected_node,
        Separator,
        Checkbox, RadioGroup,
        Button, ButtonStyle, ButtonDecoration,

--- a/src/widgets/treeview.jl
+++ b/src/widgets/treeview.jl
@@ -7,19 +7,21 @@ mutable struct TreeNode
     children::Vector{TreeNode}
     expanded::Bool
     style::Style
+    content::Any
 end
 
 function TreeNode(label::String;
     children=TreeNode[],
     expanded=true,
     style=tstyle(:text),
+    content=nothing
 )
-    TreeNode(label, children, expanded, style)
+    TreeNode(label, children, expanded, style, content)
 end
 
 function TreeNode(label::String, children::Vector{TreeNode};
-    expanded=true, style=tstyle(:text))
-    TreeNode(label, children, expanded, style)
+    expanded=true, style=tstyle(:text), content=nothing)
+    TreeNode(label, children, expanded, style, content)
 end
 
 # Flatten tree into renderable rows (defined before TreeView for cache field)
@@ -111,9 +113,10 @@ value(tv::TreeView) = tv.selected
 
 focusable(::TreeView) = true
 
-function value_node(tv::TreeView)::Union{Nothing, TreeNode}
+function selected_node(tv::TreeView)::Union{Nothing, TreeNode}
     # pick off the selected node using the selection index
-    return tv.selected == 0 ? nothing : _get_flat(tv)[tv.selected].node
+    flat = _get_flat(tv)
+    return tv.selected == 0 || tv.selected > length(flat) ? nothing : flat[tv.selected].node
 end
 
 function handle_key!(tv::TreeView, evt::KeyEvent)::Bool

--- a/src/widgets/treeview.jl
+++ b/src/widgets/treeview.jl
@@ -111,6 +111,11 @@ value(tv::TreeView) = tv.selected
 
 focusable(::TreeView) = true
 
+function value_node(tv::TreeView)::Union{Nothing, TreeNode}
+    # pick off the selected node using the selection index
+    return tv.selected == 0 ? nothing : _get_flat(tv)[tv.selected].node
+end
+
 function handle_key!(tv::TreeView, evt::KeyEvent)::Bool
     flat = _get_flat(tv)
     n = length(flat)

--- a/test/test_recording.jl
+++ b/test/test_recording.jl
@@ -72,6 +72,7 @@
         ])
         tv = T.TreeView(root; selected=2)
         @test T.value(tv) == 2
+        @test T.value_node(tv) === root.children[1]
     end
 
     @testset "value: Form" begin
@@ -146,9 +147,11 @@
         # Down moves to next
         T.handle_key!(tv, T.KeyEvent(:down))
         @test tv.selected == 2  # "a"
+        @test T.value_node(tv) === root.children[1] # "a"
         # Right on expanded node moves to first child
         T.handle_key!(tv, T.KeyEvent(:right))
         @test tv.selected == 3  # "a1"
+        @test T.value_node(tv) === root.children[1].children[1] # "a1"
     end
 
     @testset "TreeView collapse/expand" begin
@@ -173,9 +176,11 @@
         # Up from first wraps to last
         T.handle_key!(tv, T.KeyEvent(:up))
         @test tv.selected == 2
+        @test T.value_node(tv) === root.children[1]
         # Down from last wraps to first
         T.handle_key!(tv, T.KeyEvent(:down))
         @test tv.selected == 1
+        @test T.value_node(tv) === root
     end
 
     # ═════════════════════════════════════════════════════════════════

--- a/test/test_recording.jl
+++ b/test/test_recording.jl
@@ -72,7 +72,23 @@
         ])
         tv = T.TreeView(root; selected=2)
         @test T.value(tv) == 2
-        @test T.value_node(tv) === root.children[1]
+    end
+    @testset "selected_node: TreeView" begin
+        root = T.TreeNode("root"; children=[
+            T.TreeNode("child1", content=[0xf1a, "content1", -3.2e-8]),
+            T.TreeNode("child2"),
+        ])
+        tv = T.TreeView(root; selected=2)
+        @test T.value(tv) == 2
+        
+        @test T.selected_node(tv) === root.children[1]
+        @test all(T.selected_node(tv).content .== [0xf1a, "content1", -3.2e-8])
+
+        # test bounds checks when indexing outside flat:
+        tv.selected = length(T._get_flat(tv)) + 1
+        @test isnothing(T.selected_node(tv))
+        tv.selected = 0
+        @test isnothing(T.selected_node(tv))
     end
 
     @testset "value: Form" begin
@@ -147,11 +163,11 @@
         # Down moves to next
         T.handle_key!(tv, T.KeyEvent(:down))
         @test tv.selected == 2  # "a"
-        @test T.value_node(tv) === root.children[1] # "a"
+        @test T.selected_node(tv) === root.children[1] # "a"
         # Right on expanded node moves to first child
         T.handle_key!(tv, T.KeyEvent(:right))
         @test tv.selected == 3  # "a1"
-        @test T.value_node(tv) === root.children[1].children[1] # "a1"
+        @test T.selected_node(tv) === root.children[1].children[1] # "a1"
     end
 
     @testset "TreeView collapse/expand" begin
@@ -176,11 +192,11 @@
         # Up from first wraps to last
         T.handle_key!(tv, T.KeyEvent(:up))
         @test tv.selected == 2
-        @test T.value_node(tv) === root.children[1]
+        @test T.selected_node(tv) === root.children[1]
         # Down from last wraps to first
         T.handle_key!(tv, T.KeyEvent(:down))
         @test tv.selected == 1
-        @test T.value_node(tv) === root
+        @test T.selected_node(tv) === root
     end
 
     # ═════════════════════════════════════════════════════════════════

--- a/test/test_widgets_coverage.jl
+++ b/test/test_widgets_coverage.jl
@@ -991,7 +991,9 @@
         T.handle_key!(tv, T.KeyEvent(:down))
         @test !tv._flat_dirty
         @test tv.selected == 2
+        @test T.value_node(tv) === root.children[1]
         T.handle_key!(tv, T.KeyEvent(:up))
         @test !tv._flat_dirty
         @test tv.selected == 1
+        @test T.value_node(tv) === root
     end

--- a/test/test_widgets_coverage.jl
+++ b/test/test_widgets_coverage.jl
@@ -991,9 +991,9 @@
         T.handle_key!(tv, T.KeyEvent(:down))
         @test !tv._flat_dirty
         @test tv.selected == 2
-        @test T.value_node(tv) === root.children[1]
+        @test T.selected_node(tv) === root.children[1]
         T.handle_key!(tv, T.KeyEvent(:up))
         @test !tv._flat_dirty
         @test tv.selected == 1
-        @test T.value_node(tv) === root
+        @test T.selected_node(tv) === root
     end


### PR DESCRIPTION
Hello!

I'd like to propose two changes to the `TreeNode`/`TreeView` interface:
1. add a friendly way to get the currently-selected `TreeNode` out of a `TreeView`. 
2. add some sort of user-definable content to `TreeNode`, so that someone can put the data they want inside the tree and get it out with the TUI. (Like how graph/tree libraries let you add arbitrary attributes).

Together, these would make it a lot easier to use the tree widget to interact with complex models. One could just ask the `TreeView` for the current `TreeNode` selection and pull their data out of it, without depending on the current state of the view to figure out what `TreeView.selection` means.

### 1: Getting a `TreeNode` out of a `TreeView`

What I have added to the PR so far: 
- added an exported `value_node(tv::TreeView)::Union{TreeNode, Nothing}` method, which acts like the existing `value(tv::TreeView')::Int`, but returns the `TreeNode`. 
- added a couple tests for the new method.
- added a simple example: `demos/TachikomaDemos/simple_tree_demo.jl` which just displays the output of `value()` and `value_node()`, live.

### 2: Storing user data in `TreeNode`

My idea for this is to add a parametric field `content` to `TreeNode`, so it looks like:
```julia
mutable struct TreeNode{T<:Any}
    label::String
    children::Vector{TreeNode{T}}
    expanded::Bool
    style::Style
    content::T
end
```

Then if I want to keep track of `Vector{UInt32}`s or whatever in my tree, I just build it out of `TreeNode{Vector{UInt32}}(...)`. 

Note that this would force `TreeView` to also become a parametric type.

An alternative would be adding some kind of unique ID to each `TreeNode`, but that's hard to enforce without a system to construct trees.

I would add an outer constructor which defaults the new `.content` field to `nothing` to avoid breaking existing trees.

### Questions for @kahliburke:
- Adding the method `value_node(tv::TreeView)` expands the current small, nice API for widgets. An alternative is to make `value(tv::TreeView)` return a tuple with the current `TreeView.selection` and the selected TreeNode to avoid a specialized method. Or something similar. What do you prefer?
- Thoughts on the proposal to add parametric `.content{T}` to `TreeNode`? I'll implement it and add to this PR if no objections.