### PR TITLE
feat: render into a caller-supplied IO sink (with_terminal/app io kwarg)

### DIFF
--- a/demos/TachikomaDemos/Project.toml
+++ b/demos/TachikomaDemos/Project.toml
@@ -13,7 +13,7 @@ SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tachikoma = "468859d6-42d8-48b7-8ad9-1d312e0e3b0a"
 
 [sources]
-Tachikoma = {path = "../.."}
+Tachikoma = {path = "/Users/scelles/src/tries/tachikoma-pr39/test/.."}
 
 [compat]
 ColorTypes = "0.12.1"

--- a/demos/TachikomaDemos/Project.toml
+++ b/demos/TachikomaDemos/Project.toml
@@ -13,7 +13,7 @@ SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 Tachikoma = "468859d6-42d8-48b7-8ad9-1d312e0e3b0a"
 
 [sources]
-Tachikoma = {path = "/Users/scelles/src/tries/tachikoma-pr39/test/.."}
+Tachikoma = {path = "../.."}
 
 [compat]
 ColorTypes = "0.12.1"

--- a/src/Tachikoma.jl
+++ b/src/Tachikoma.jl
@@ -67,7 +67,7 @@ export # Core types
        ResizableLayout, handle_resize!, reset_layout!, render_resize_handles!,
        # App framework
        app, @tachikoma_app, set_wake!,
-       tty_path,
+       tty_path, set_size!,
        prepare_for_exec!,
        clipboard_copy!, buffer_to_text,
        # Async tasks

--- a/src/app.jl
+++ b/src/app.jl
@@ -989,7 +989,7 @@ function _try_put!(ch::Channel{Nothing})
 end
 
 """
-    app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing)
+    app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, io=nothing, input=nothing, tty_out=nothing, tty_size=nothing, on_terminal=nothing)
 
 Run a TUI application with the Elm architecture loop: poll events → `update!` → `view`.
 Enters the alternate screen, enables raw mode and mouse, then renders at `fps` frames/sec.

--- a/src/app.jl
+++ b/src/app.jl
@@ -1001,7 +1001,7 @@ Stdout and stderr are automatically redirected during TUI mode to prevent backgr
 `println()` from corrupting the display. Pass `on_stdout` / `on_stderr` callbacks to
 receive captured lines (e.g., for an activity log). See [`with_terminal`](@ref).
 """
-function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, io=nothing, tty_out=nothing, tty_size=nothing)
+function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, io=nothing, tty_out=nothing, tty_size=nothing, on_terminal=nothing)
     # Preserve real stdin for the event loop before any REPL widget
     # redirects Base.stdin to its PTY slave (for interactive prompts).
     # We dup fd 0 to get an independent fd to the real terminal —
@@ -1020,6 +1020,12 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
     _app_error = Ref{Any}(nothing)
     _app_bt = Ref{Any}(nothing)
     with_terminal(; io, on_stdout, on_stderr, tty_out, tty_size) do t
+        # Hand the live Terminal to the caller once, before the loop. A
+        # driver that owns the sink but not the Terminal -- a web bridge
+        # feeding an injected `io` -- needs this to push resizes in with
+        # `resize!(t, sz)`; `app` builds the Terminal internally and would
+        # otherwise never expose it.
+        on_terminal === nothing || on_terminal(t)
         init!(model, t)
         _load_layout_prefs!(model)
         overlay = AppOverlay()

--- a/src/app.jl
+++ b/src/app.jl
@@ -1001,7 +1001,7 @@ Stdout and stderr are automatically redirected during TUI mode to prevent backgr
 `println()` from corrupting the display. Pass `on_stdout` / `on_stderr` callbacks to
 receive captured lines (e.g., for an activity log). See [`with_terminal`](@ref).
 """
-function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, tty_out=nothing, tty_size=nothing)
+function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, io=nothing, tty_out=nothing, tty_size=nothing)
     # Preserve real stdin for the event loop before any REPL widget
     # redirects Base.stdin to its PTY slave (for interactive prompts).
     # We dup fd 0 to get an independent fd to the real terminal —
@@ -1019,7 +1019,7 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
     _restarting = Ref(false)
     _app_error = Ref{Any}(nothing)
     _app_bt = Ref{Any}(nothing)
-    with_terminal(; on_stdout, on_stderr, tty_out, tty_size) do t
+    with_terminal(; io, on_stdout, on_stderr, tty_out, tty_size) do t
         init!(model, t)
         _load_layout_prefs!(model)
         overlay = AppOverlay()

--- a/src/app.jl
+++ b/src/app.jl
@@ -1013,7 +1013,8 @@ receive captured lines (e.g., for an activity log). See [`with_terminal`](@ref).
   dup'd, so this works headless.
 - `input` — read keystrokes from here rather than the terminal. A
   headless/remote caller supplies its own input source; without it the app
-  takes no input.
+  takes no input. Takes precedence over an `INPUT_IO` a host already
+  installed, and that previous source is restored when the app exits.
 - `on_terminal` — a `f(t::Terminal)` called once, before the loop, with the
   live `Terminal`. The only way a driver that owns the sink but not the
   terminal gets a handle to call [`set_size!`](@ref) on when its viewport
@@ -1025,22 +1026,31 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
     # We dup fd 0 to get an independent fd to the real terminal —
     # redirect_stdin does dup2 which overwrites fd 0, so the original
     # stdin Julia object would read from the wrong source.
-    _saved_input = INPUT_IO[] === nothing
+    # Remember whatever source was already installed so teardown can put it
+    # back. An explicit `input` takes precedence for the life of this app, but
+    # a host that installed its own source must get it back afterwards.
+    _prev_input = INPUT_IO[]
+    _restore_input = false
     if input !== nothing
         # Explicit input source (a socket, a pipe): a headless/remote caller
-        # feeds keystrokes from here, not the terminal.
-        _saved_input && (INPUT_IO[] = input)
+        # feeds keystrokes from here, not the terminal. This WINS over anything
+        # already in INPUT_IO -- the caller named this source, and deferring to
+        # a pre-existing one instead leaves the app taking no keys at all with
+        # nothing on screen to explain why.
+        INPUT_IO[] = input
+        _restore_input = true
     elseif io !== nothing
         # Injected sink: fd 0 is not a tty here, so dup'ing it throws EINVAL
         # (the exact headless case this targets). Skip the dup entirely --
         # input arrives through `input`/`INPUT_IO`, or the app takes none.
-    elseif _saved_input
+    elseif _prev_input === nothing
         @static if Sys.iswindows()
             INPUT_IO[] = stdin
         else
             saved_fd = ccall(:dup, Cint, (Cint,), Cint(0))
             INPUT_IO[] = Base.TTY(RawFD(saved_fd))
         end
+        _restore_input = true
     end
     _restarting = Ref(false)
     _app_error = Ref{Any}(nothing)
@@ -1213,7 +1223,7 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
     # cleanup! runs after with_terminal returns — terminal is fully restored
     # (leave_tui!, raw mode off, alt screen off) before app teardown begins.
     cleanup!(model)
-    _saved_input && (INPUT_IO[] = nothing)
+    _restore_input && (INPUT_IO[] = _prev_input)
     if _app_error[] !== nothing
         Base.showerror(stderr, _app_error[], _app_bt[])
         println(stderr)

--- a/src/app.jl
+++ b/src/app.jl
@@ -1000,15 +1000,36 @@ Set `default_bindings=false` to disable built-in shortcuts
 Stdout and stderr are automatically redirected during TUI mode to prevent background
 `println()` from corrupting the display. Pass `on_stdout` / `on_stderr` callbacks to
 receive captured lines (e.g., for an activity log). See [`with_terminal`](@ref).
+
+## Driving the app from somewhere other than a terminal
+
+- `io` — render into this sink instead of a terminal (a socket, a pipe, an
+  `IOBuffer`). `tty_size = (rows, cols)` is then required. fd 0 is not
+  dup'd, so this works headless.
+- `input` — read keystrokes from here rather than the terminal. A
+  headless/remote caller supplies its own input source; without it the app
+  takes no input.
+- `on_terminal` — a `f(t::Terminal)` called once, before the loop, with the
+  live `Terminal`. The only way a driver that owns the sink but not the
+  terminal gets a handle to call [`set_size!`](@ref) on when its viewport
+  changes.
 """
-function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, io=nothing, tty_out=nothing, tty_size=nothing, on_terminal=nothing)
+function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_stderr=nothing, io=nothing, input=nothing, tty_out=nothing, tty_size=nothing, on_terminal=nothing)
     # Preserve real stdin for the event loop before any REPL widget
     # redirects Base.stdin to its PTY slave (for interactive prompts).
     # We dup fd 0 to get an independent fd to the real terminal —
     # redirect_stdin does dup2 which overwrites fd 0, so the original
     # stdin Julia object would read from the wrong source.
     _saved_input = INPUT_IO[] === nothing
-    if _saved_input
+    if input !== nothing
+        # Explicit input source (a socket, a pipe): a headless/remote caller
+        # feeds keystrokes from here, not the terminal.
+        _saved_input && (INPUT_IO[] = input)
+    elseif io !== nothing
+        # Injected sink: fd 0 is not a tty here, so dup'ing it throws EINVAL
+        # (the exact headless case this targets). Skip the dup entirely --
+        # input arrives through `input`/`INPUT_IO`, or the app takes none.
+    elseif _saved_input
         @static if Sys.iswindows()
             INPUT_IO[] = stdin
         else
@@ -1023,7 +1044,7 @@ function app(model::Model; fps=60, default_bindings=true, on_stdout=nothing, on_
         # Hand the live Terminal to the caller once, before the loop. A
         # driver that owns the sink but not the Terminal -- a web bridge
         # feeding an injected `io` -- needs this to push resizes in with
-        # `resize!(t, sz)`; `app` builds the Terminal internally and would
+        # `set_size!(t, sz)`; `app` builds the Terminal internally and would
         # otherwise never expose it.
         on_terminal === nothing || on_terminal(t)
         init!(model, t)

--- a/src/terminal.jl
+++ b/src/terminal.jl
@@ -1609,17 +1609,31 @@ so the guard-application is unit-testable without a real terminal."""
 _run_guarded(body) = (g = _STREAM_GUARD[]; g === nothing ? body() : g(body))
 
 """
-    with_terminal(f; tty_out=nothing, on_stdout=nothing, on_stderr=nothing)
+    with_terminal(f; io=nothing, tty_out=nothing, tty_size=nothing,
+                  on_stdout=nothing, on_stderr=nothing)
 
 Run `f(terminal)` inside the TUI lifecycle (alt screen, raw mode, mouse).
 
-Stdout and stderr are always redirected to pipes during TUI mode to prevent
-background `println()` calls from corrupting the display. Rendering goes to
-`/dev/tty` directly, bypassing the redirected file descriptors.
+Stdout and stderr are redirected to pipes during TUI mode to prevent background
+`println()` calls from corrupting the display. Rendering goes to `/dev/tty`
+directly, bypassing the redirected file descriptors.
 
 Pass `on_stdout` / `on_stderr` callbacks to receive captured lines (e.g., for
 an activity log). When no callbacks are provided, captured output is silently
 discarded.
+
+Pass `io` to render into a sink you already hold — a socket, a pipe, an
+`IOBuffer` — instead of a terminal this process is attached to. `tty_size =
+(rows = ..., cols = ...)` is then required, since an arbitrary sink cannot be
+probed for its size, and [`set_size!`](@ref) is how you later declare a resize.
+The sink is yours: `with_terminal` never closes an `io` it did not open.
+
+With `io`, stdout/stderr are NOT redirected unless you asked for the lines with
+`on_stdout`/`on_stderr`. The redirect is process-wide, and an injected sink has
+no shared terminal display for stray output to corrupt — the very thing the
+capture protects. This is what lets an embedding host (a notebook worker, a
+server) run a Tachikoma app without losing the stream it talks to its parent
+over.
 
 Pass `tty_out` with a path like `"/dev/ttys042"` to render into a different
 terminal window than the one running the Julia process. Run `cat > /dev/null`
@@ -1664,8 +1678,20 @@ function with_terminal(f::Function; io=nothing, tty_out=nothing, tty_size=nothin
         else
             terminal_size()
         end
-        state = _start_capture(something(on_stdout, _DISCARD_OUTPUT),
-                               something(on_stderr, _DISCARD_OUTPUT))
+        # The capture exists so a stray `println` cannot corrupt the frames on a terminal
+        # this process shares with the app. An injected sink HAS no such terminal -- that
+        # is what makes it injected -- so there is nothing to protect, and capturing
+        # anyway is actively harmful: `_start_capture` calls `redirect_stdout()` on the
+        # WHOLE process, so an embedding host (a notebook worker, a server) loses the
+        # stream it talks to its parent over. The `on_stdout !== nothing` guard inside
+        # `_start_capture` cannot prevent this: `something(...)` has already substituted
+        # `_DISCARD_OUTPUT` by the time it is consulted, so it is never `nothing`.
+        #
+        # An explicit `on_stdout`/`on_stderr` is still honoured -- the caller asked for
+        # the lines, so they are still captured and delivered.
+        state = (io === nothing || on_stdout !== nothing || on_stderr !== nothing) ?
+                _start_capture(something(on_stdout, _DISCARD_OUTPUT),
+                               something(on_stderr, _DISCARD_OUTPUT)) : nothing
         t = Terminal(io = tty_io, size = sz, remote_tty_path = tty_out,
                      external_size = io !== nothing)
         # remote_tty is what keeps this off the local terminal: it skips raw mode
@@ -1679,7 +1705,7 @@ function with_terminal(f::Function; io=nothing, tty_out=nothing, tty_size=nothin
             f(t)
         finally
             leave_tui!(t)
-            _stop_capture(state)
+            state === nothing || _stop_capture(state)
             # A caller-supplied `io` is the caller's to close: a websocket that
             # outlives one app must not be closed out from under them.
             (io === nothing && tty_io !== stdout) && try close(tty_io) catch end

--- a/src/terminal.jl
+++ b/src/terminal.jl
@@ -131,12 +131,25 @@ mutable struct Terminal
     kitty_keyboard::Bool                        # true if Kitty keyboard protocol is active
     graphics_protocol::GraphicsProtocol         # detected graphics protocol (sixel/kitty/none)
     remote_tty_path::Union{String,Nothing}      # path to remote TTY (nothing = local); enables periodic size polling
+    external_size::Bool                         # true when io was injected: size is the caller's to declare, never probed
 end
 
-function Terminal(; io::IO = stdout, size = nothing, remote_tty_path::Union{String,Nothing} = nothing)
+# The thirteen-field positional form, from before `external_size` existed.
+# Callers that spelled every field out in order predate the flag and mean a
+# terminal whose size is probed, which is what `false` says.
+Terminal(buffers::Vector{Buffer}, current::Int, size::Rect, mouse_enabled::Bool,
+         had_gfx::Bool, prev_gfx_bounds::Vector{NTuple{4,Int}}, frame_count::Int,
+         clear_interval::Int, recorder::CastRecorder, io::IO,
+         kitty_keyboard::Bool, graphics_protocol::GraphicsProtocol,
+         remote_tty_path::Union{String,Nothing}) =
+    Terminal(buffers, current, size, mouse_enabled, had_gfx, prev_gfx_bounds,
+             frame_count, clear_interval, recorder, io, kitty_keyboard,
+             graphics_protocol, remote_tty_path, false)
+
+function Terminal(; io::IO = stdout, size = nothing, remote_tty_path::Union{String,Nothing} = nothing, external_size::Bool = false)
     sz = something(size, terminal_size())
     rect = Rect(1, 1, sz.cols, sz.rows)
-    Terminal([Buffer(rect), Buffer(rect)], 1, rect, true, false, NTuple{4,Int}[], 0, 300, CastRecorder(), io, false, gfx_none, remote_tty_path)
+    Terminal([Buffer(rect), Buffer(rect)], 1, rect, true, false, NTuple{4,Int}[], 0, 300, CastRecorder(), io, false, gfx_none, remote_tty_path, external_size)
 end
 
 # Query terminal dimensions from an arbitrary TTY path using `stty size`.
@@ -1270,7 +1283,35 @@ function _stop_remote_input!()
     nothing
 end
 
+"""
+    resize!(t::Terminal, sz)
+
+Declare `t`'s new size, where `sz` is `(rows = ..., cols = ...)`.
+
+For a terminal over an injected `io`, this is the ONLY way its size ever
+changes: there is no tty to probe and no SIGWINCH to catch, so the caller
+who owns the sink -- a websocket that just received a resize frame, say --
+has to say so. Returns `true` when the size actually changed, matching
+`check_resize!`, so `draw!` clears on the next frame.
+"""
+function Base.resize!(t::Terminal, sz)
+    new_rect = Rect(1, 1, sz.cols, sz.rows)
+    new_rect == t.size && return false
+    t.size = new_rect
+    for buf in t.buffers
+        resize_buf!(buf, new_rect)
+    end
+    return true
+end
+
 function check_resize!(t::Terminal)
+    # An injected sink cannot be probed: it is not a tty and has no size of
+    # its own. Probing anyway reaches for stdout, which under the app's own
+    # stdout capture is a pipe, so terminal_size() returns its 80x24 default
+    # and every frame is silently resized to the wrong dimensions. The
+    # caller who supplied the sink is the only one who knows how big it is,
+    # and says so through `resize!`.
+    t.external_size && return false
     if t.remote_tty_path !== nothing
         # Remote TTY: SIGWINCH doesn't reach us, so poll periodically (once per second at 60fps).
         t.frame_count % 60 == 0 || return false
@@ -1552,33 +1593,60 @@ absorbs any buffered input without displaying it. Input (keyboard/mouse)
 continues to come from the current terminal or via synthetic events. Terminal
 resize is supported via periodic size polling (once per second).
 """
-function with_terminal(f::Function; tty_out=nothing, tty_size=nothing, on_stdout=nothing, on_stderr=nothing)
-    # Skip pixel detection when rendering to a remote TTY — detection queries
-    # the current terminal (not tty_out) and its escape-sequence responses
-    # buffer up in the remote TTY's input, corrupting the shell on exit.
-    tty_out === nothing && detect_cell_pixels!()
-    tty_io = if tty_out !== nothing
+function with_terminal(f::Function; io=nothing, tty_out=nothing, tty_size=nothing, on_stdout=nothing, on_stderr=nothing)
+    # `io` is the sink itself rather than a path to one: a socket, a pipe, an
+    # IOBuffer. `Terminal` has always been IO-polymorphic — every write goes
+    # through `t.io` — but `with_terminal` could only ever BUILD that sink from
+    # a path, so the only reachable sinks were /dev/tty, a tty path, or stdout.
+    # An injected sink is a remote terminal in every respect that matters: it is
+    # not the terminal this process is attached to.
+    _remote = tty_out !== nothing || io !== nothing
+    if io !== nothing && tty_size === nothing
+        # Size cannot be probed from an arbitrary sink, and guessing would put
+        # every frame at the wrong dimensions. Make the caller say.
+        throw(ArgumentError("with_terminal: `tty_size = (rows = ..., cols = ...)` " *
+                            "is required when `io` is given -- an injected sink " *
+                            "cannot be probed for its size"))
+    end
+    # Skip pixel detection when frames go anywhere but the current terminal —
+    # detection queries the CURRENT terminal, so its escape-sequence replies
+    # buffer up in the wrong place and corrupt that terminal on exit.
+    _remote || detect_cell_pixels!()
+    tty_io = if io !== nothing
+        io
+    elseif tty_out !== nothing
         open(tty_out, "w")
     elseif Sys.iswindows()
         stdout
     else
         open("/dev/tty", "w")
     end
-    sz = if tty_out !== nothing
+    sz = if io !== nothing
+        tty_size
+    elseif tty_out !== nothing
         something(tty_size, _tty_size(tty_out))
     else
         terminal_size()
     end
     state = _start_capture(something(on_stdout, _DISCARD_OUTPUT),
                            something(on_stderr, _DISCARD_OUTPUT))
-    t = Terminal(io = tty_io, size = sz, remote_tty_path = tty_out)
-    enter_tui!(t; remote_tty = tty_out !== nothing)
+    t = Terminal(io = tty_io, size = sz, remote_tty_path = tty_out,
+                 external_size = io !== nothing)
+    # remote_tty is what keeps this off the local terminal: it skips raw mode
+    # on the process's own stdin, and skips the kitty/graphics probes that
+    # would write to a terminal that is not where the frames are going. With
+    # `io` there is no remote_tty_path either, so `_start_remote_input!` is
+    # correctly skipped -- an injected sink's input arrives by whatever route
+    # the caller chose (see `INPUT_IO`), not from a tty this process can open.
+    enter_tui!(t; remote_tty = _remote)
     try
         f(t)
     finally
         leave_tui!(t)
         _stop_capture(state)
-        tty_io !== stdout && try close(tty_io) catch end
+        # A caller-supplied `io` is the caller's to close: a websocket that
+        # outlives one app must not be closed out from under them.
+        (io === nothing && tty_io !== stdout) && try close(tty_io) catch end
     end
 end
 

--- a/src/terminal.jl
+++ b/src/terminal.jl
@@ -132,6 +132,7 @@ mutable struct Terminal
     graphics_protocol::GraphicsProtocol         # detected graphics protocol (sixel/kitty/none)
     remote_tty_path::Union{String,Nothing}      # path to remote TTY (nothing = local); enables periodic size polling
     external_size::Bool                         # true when io was injected: size is the caller's to declare, never probed
+    pending_clear::Bool                         # set by set_size! on an external resize; check_resize! consumes it to emit CLEAR_SCREEN once
 end
 
 # The thirteen-field positional form, from before `external_size` existed.
@@ -144,12 +145,12 @@ Terminal(buffers::Vector{Buffer}, current::Int, size::Rect, mouse_enabled::Bool,
          remote_tty_path::Union{String,Nothing}) =
     Terminal(buffers, current, size, mouse_enabled, had_gfx, prev_gfx_bounds,
              frame_count, clear_interval, recorder, io, kitty_keyboard,
-             graphics_protocol, remote_tty_path, false)
+             graphics_protocol, remote_tty_path, false, false)
 
 function Terminal(; io::IO = stdout, size = nothing, remote_tty_path::Union{String,Nothing} = nothing, external_size::Bool = false)
     sz = something(size, terminal_size())
     rect = Rect(1, 1, sz.cols, sz.rows)
-    Terminal([Buffer(rect), Buffer(rect)], 1, rect, true, false, NTuple{4,Int}[], 0, 300, CastRecorder(), io, false, gfx_none, remote_tty_path, external_size)
+    Terminal([Buffer(rect), Buffer(rect)], 1, rect, true, false, NTuple{4,Int}[], 0, 300, CastRecorder(), io, false, gfx_none, remote_tty_path, external_size, false)
 end
 
 # Query terminal dimensions from an arbitrary TTY path using `stty size`.
@@ -1284,23 +1285,28 @@ function _stop_remote_input!()
 end
 
 """
-    resize!(t::Terminal, sz)
+    set_size!(t::Terminal, sz)
 
 Declare `t`'s new size, where `sz` is `(rows = ..., cols = ...)`.
 
 For a terminal over an injected `io`, this is the ONLY way its size ever
 changes: there is no tty to probe and no SIGWINCH to catch, so the caller
 who owns the sink -- a websocket that just received a resize frame, say --
-has to say so. Returns `true` when the size actually changed, matching
-`check_resize!`, so `draw!` clears on the next frame.
+has to say so.
+
+Returns `true` when the size actually changed. It also arms a one-shot
+clear: the NEXT `check_resize!` returns `true`, so `draw!` emits
+`CLEAR_SCREEN` and stale glyphs outside a shrunk region are wiped from the
+receiver, exactly as the tty resize path does.
 """
-function Base.resize!(t::Terminal, sz)
+function set_size!(t::Terminal, sz)
     new_rect = Rect(1, 1, sz.cols, sz.rows)
     new_rect == t.size && return false
     t.size = new_rect
     for buf in t.buffers
         resize_buf!(buf, new_rect)
     end
+    t.pending_clear = true
     return true
 end
 
@@ -1310,8 +1316,13 @@ function check_resize!(t::Terminal)
     # stdout capture is a pipe, so terminal_size() returns its 80x24 default
     # and every frame is silently resized to the wrong dimensions. The
     # caller who supplied the sink is the only one who knows how big it is,
-    # and says so through `resize!`.
-    t.external_size && return false
+    # and says so through `set_size!` -- which arms `pending_clear`, consumed
+    # here so `draw!` clears once after the resize.
+    if t.external_size
+        t.pending_clear || return false
+        t.pending_clear = false
+        return true
+    end
     if t.remote_tty_path !== nothing
         # Remote TTY: SIGWINCH doesn't reach us, so poll periodically (once per second at 60fps).
         t.frame_count % 60 == 0 || return false

--- a/src/terminal.jl
+++ b/src/terminal.jl
@@ -1389,7 +1389,21 @@ function _detect_graphics_from_env()
     return gfx_none
 end
 
-function enter_tui!(t::Terminal; remote_tty::Bool = false)
+"""
+    _is_remote_terminal(t::Terminal) → Bool
+
+Whether `t`'s frames go somewhere other than the terminal this process owns —
+a `tty_out` path, or an `io` sink handed in by the caller.
+
+Both `enter_tui!` and `leave_tui!` branch on this, and they must agree: setup
+skips raw mode on the process's own stdin precisely because that stdin is not
+the app's input, so teardown must not switch it back. Deriving both from this
+one predicate is what keeps them from drifting — `remote_tty_path` alone does
+not, since an injected `io` leaves it `nothing`.
+"""
+_is_remote_terminal(t::Terminal) = t.remote_tty_path !== nothing || t.external_size
+
+function enter_tui!(t::Terminal; remote_tty::Bool = _is_remote_terminal(t))
     print(t.io, ALT_SCREEN_ON, CURSOR_HIDE, CLEAR_SCREEN)
     Base.flush(t.io)
     if remote_tty
@@ -1488,8 +1502,13 @@ function leave_tui!(t::Terminal)
     # stdin buffer.  stop_input! then drains that buffer.
     try sleep(0.015) catch end
     try stop_input!() catch end
-    if t.remote_tty_path !== nothing
-        try _stop_remote_input!() catch end
+    if _is_remote_terminal(t)
+        # Frames went somewhere other than this process's terminal, so setup
+        # never touched its stdin. Only a tty_out path has remote input to stop;
+        # an injected io has none. Either way, leave the host's stdin alone --
+        # set_raw_mode!(false) is unconditional once stdin is a TTY, so calling
+        # it here would drop an embedding REPL out of raw mode on every exit.
+        t.remote_tty_path === nothing || try _stop_remote_input!() catch end
     else
         try set_raw_mode!(false) catch end
     end
@@ -1700,7 +1719,9 @@ function with_terminal(f::Function; io=nothing, tty_out=nothing, tty_size=nothin
         # `io` there is no remote_tty_path either, so `_start_remote_input!` is
         # correctly skipped -- an injected sink's input arrives by whatever route
         # the caller chose (see `INPUT_IO`), not from a tty this process can open.
-        enter_tui!(t; remote_tty = _remote)
+        # `_is_remote_terminal(t)` is `_remote` by construction, and letting
+        # enter_tui!/leave_tui! both read it keeps teardown in step with setup.
+        enter_tui!(t)
         try
             f(t)
         finally

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ struct _DummyModel <: T.Model end
     include("test_markdown.jl")
     include("test_widgets_coverage.jl")
     include("test_scripting.jl")
+    include("test_injectable_io.jl")
     include("test_animation.jl")
     include("test_tokenizers.jl")
     include("test_style.jl")

--- a/test/test_injectable_io.jl
+++ b/test/test_injectable_io.jl
@@ -1,0 +1,111 @@
+# test_injectable_io.jl -- `T.with_terminal(io = ...)` / `app(io = ...)`.
+#
+# The claim under test is that frames can be pointed at a sink this process
+# did not open, with no terminal involved anywhere: no /dev/tty, no raw mode
+# on stdin, no probe escapes written to whatever terminal happens to be
+# attached. That is what lets a Tachikoma app be driven by something other
+# than a tty -- a websocket, a pipe, a recording.
+
+@testset "injectable io" begin
+    @testset "with_terminal renders into an injected sink" begin
+        sink = IOBuffer()
+        got = T.with_terminal(; io = sink, tty_size = (rows = 10, cols = 40)) do t
+            @test t.io === sink
+            @test t.size == Rect(1, 1, 40, 10)
+            T.draw!(t) do f
+                render(Block(title = "hi"), f.area, f.buffer)
+            end
+            :ran
+        end
+        @test got === :ran
+        out = String(take!(copy(sink)))
+        # The alt screen went to OUR buffer, which is the whole point: the
+        # frame stream is addressable.
+        @test !isempty(out)
+        @test occursin("\e[?1049h", out)   # ALT_SCREEN_ON
+    end
+
+    @testset "an injected sink demands a size" begin
+        # Guessing would put every frame at the wrong dimensions, and the
+        # sink cannot be probed. Fail loudly at the call, not visually later.
+        @test_throws ArgumentError T.with_terminal(identity; io = IOBuffer())
+    end
+
+    @testset "the caller's sink is the caller's to close" begin
+        # A websocket outlives any one app; closing it here would take the
+        # connection down with the app.
+        sink = IOBuffer()
+        T.with_terminal(; io = sink, tty_size = (rows = 5, cols = 20)) do t
+            nothing
+        end
+        @test isopen(sink)
+        # ...whereas the paths with_terminal opened ITSELF are still its own.
+    end
+
+    @testset "the injected size survives draw!" begin
+        # The regression this pins: draw! calls check_resize!, which probed
+        # terminal_size() whenever remote_tty_path was nothing -- which is
+        # exactly the injected-io case. Under the app's own stdout capture
+        # that probe reaches a pipe and returns its 80x24 default, so every
+        # frame was silently resized to the wrong dimensions while t.size
+        # still read correctly.
+        sink = IOBuffer()
+        T.with_terminal(; io = sink, tty_size = (rows = 7, cols = 33)) do t
+            @test t.size == Rect(1, 1, 33, 7)
+            T.draw!(t) do f
+                @test f.area.width == 33
+                @test f.area.height == 7
+            end
+        end
+    end
+
+    @testset "app() drives a real Model into an injected sink" begin
+        # The whole point, end to end: a Model/view/update app rendered
+        # through app() with no terminal anywhere -- the frames land in a
+        # buffer this test owns. A self-quitting model ends the loop, so no
+        # input source is needed to make app() return.
+        @kwdef mutable struct _Hello <: T.Model
+            frames::Int = 0
+        end
+        T.should_quit(m::_Hello) = m.frames >= 3
+        function T.view(m::_Hello, f::T.Frame)
+            m.frames += 1
+            render(Block(title = "hi from a sink"), f.area, f.buffer)
+        end
+
+        sink = IOBuffer()
+        model = _Hello()
+        # Supply the input source up front. app() only dups fd 0 when
+        # INPUT_IO is unset, and under the test harness fd 0 is not a tty
+        # (dup'ing it throws EINVAL) -- but a socket-driven caller sets its
+        # own input source anyway, which is exactly what this models.
+        old_input = T.INPUT_IO[]
+        T.INPUT_IO[] = IOBuffer()
+        try
+            app(model; io = sink, tty_size = (rows = 8, cols = 40), fps = 120)
+        finally
+            T.INPUT_IO[] = old_input
+        end
+        out = String(take!(copy(sink)))
+        @test model.frames >= 3
+        @test occursin("hi from a sink", out)
+        @test occursin("\e[?1049h", out)          # alt screen, into OUR sink
+        @test occursin('─', out) || occursin('│', out)  # a box was drawn
+    end
+
+    @testset "resize! is how an injected sink changes size" begin
+        # No tty to probe and no SIGWINCH to catch: the caller who owns the
+        # sink is the only one who knows, so it has to say.
+        sink = IOBuffer()
+        T.with_terminal(; io = sink, tty_size = (rows = 7, cols = 33)) do t
+            @test resize!(t, (rows = 12, cols = 50)) == true
+            @test t.size == Rect(1, 1, 50, 12)
+            T.draw!(t) do f
+                @test f.area.width == 50
+                @test f.area.height == 12
+            end
+            # Unchanged size is not a resize -- draw! keys its clear off this.
+            @test resize!(t, (rows = 12, cols = 50)) == false
+        end
+    end
+end

--- a/test/test_injectable_io.jl
+++ b/test/test_injectable_io.jl
@@ -138,6 +138,30 @@
         end
     end
 
+    @testset "teardown does not touch the host's stdin" begin
+        # enter_tui! skips raw mode on this process's stdin for an injected sink,
+        # so leave_tui! must skip restoring it. The two used to disagree:
+        # leave_tui! branched on remote_tty_path, which an injected io leaves
+        # `nothing`, so it fell through to set_raw_mode!(false) -- unconditional
+        # once stdin is a TTY. An embedding host (a REPL, a gate process) would
+        # be dropped out of raw mode every time an app exited.
+        #
+        # Asserted on the predicate rather than the syscall: set_raw_mode! is a
+        # no-op when stdin isn't a TTY, which is exactly the case under CI, so a
+        # behavioural test here would pass no matter what the branch did.
+        sink = IOBuffer()
+        T.with_terminal(; io = sink, tty_size = (rows = 6, cols = 20)) do t
+            @test T._is_remote_terminal(t) == true
+            @test t.remote_tty_path === nothing   # ...and so is NOT detected by that
+        end
+        # A terminal this process does own still restores raw mode as before.
+        @test T._is_remote_terminal(T.Terminal(io = IOBuffer(),
+                                               size = (rows = 6, cols = 20))) == false
+        # A tty_out terminal is remote too, and additionally has input to stop.
+        @test T._is_remote_terminal(T.Terminal(io = IOBuffer(), size = (rows = 6, cols = 20),
+                                               remote_tty_path = "/dev/ttys999")) == true
+    end
+
     @testset "an injected sink does not redirect the process's streams" begin
         # The capture protects a terminal the app SHARES with background `println`s.
         # An injected sink has no such terminal, and the redirect is process-wide --

--- a/test/test_injectable_io.jl
+++ b/test/test_injectable_io.jl
@@ -137,4 +137,40 @@
             @test !occursin("\e[2J", String(take!(sink)))
         end
     end
+
+    @testset "an injected sink does not redirect the process's streams" begin
+        # The capture protects a terminal the app SHARES with background `println`s.
+        # An injected sink has no such terminal, and the redirect is process-wide --
+        # so an embedding host (a notebook worker, a server) that talks to its parent
+        # over stdout would lose that stream the moment it ran an app. Note this is
+        # NOT covered by the `on_stdout !== nothing` guard inside `_start_capture`:
+        # `something(on_stdout, _DISCARD_OUTPUT)` has already replaced it by then.
+        sink = IOBuffer()
+        before_out, before_err = stdout, stderr
+        seen_out, seen_err = Ref{Any}(nothing), Ref{Any}(nothing)
+        T.with_terminal(; io = sink, tty_size = (rows = 6, cols = 20)) do t
+            seen_out[] = stdout
+            seen_err[] = stderr
+        end
+        @test seen_out[] === before_out
+        @test seen_err[] === before_err
+        @test stdout === before_out          # and nothing was left swapped out
+        @test stderr === before_err
+    end
+
+    @testset "an injected sink still captures when the caller asks for the lines" begin
+        # Opting in with on_stdout means the caller WANTS the output, so the redirect
+        # is theirs to have -- skipping it would silently drop the lines they asked for.
+        sink = IOBuffer()
+        lines = String[]
+        before = stdout
+        T.with_terminal(; io = sink, tty_size = (rows = 6, cols = 20),
+                        on_stdout = l -> push!(lines, l)) do t
+            @test stdout !== before          # redirected, because it was requested
+            println("captured please")
+            flush(stdout)
+        end
+        @test stdout === before              # ...and restored afterwards
+        @test any(l -> occursin("captured please", l), lines)
+    end
 end

--- a/test/test_injectable_io.jl
+++ b/test/test_injectable_io.jl
@@ -75,17 +75,12 @@
 
         sink = IOBuffer()
         model = _Hello()
-        # Supply the input source up front. app() only dups fd 0 when
-        # INPUT_IO is unset, and under the test harness fd 0 is not a tty
-        # (dup'ing it throws EINVAL) -- but a socket-driven caller sets its
-        # own input source anyway, which is exactly what this models.
-        old_input = T.INPUT_IO[]
-        T.INPUT_IO[] = IOBuffer()
-        try
-            app(model; io = sink, tty_size = (rows = 8, cols = 40), fps = 120)
-        finally
-            T.INPUT_IO[] = old_input
-        end
+        # No manual INPUT_IO: with `io`, app() skips the fd-0 dup that would
+        # throw EINVAL headless, and `input` is the public way a socket-driven
+        # caller feeds keystrokes. An empty buffer is enough here -- the model
+        # self-quits.
+        app(model; io = sink, tty_size = (rows = 8, cols = 40), fps = 120,
+            input = IOBuffer())
         out = String(take!(copy(sink)))
         @test model.frames >= 3
         @test occursin("hi from a sink", out)
@@ -93,19 +88,53 @@
         @test occursin('─', out) || occursin('│', out)  # a box was drawn
     end
 
-    @testset "resize! is how an injected sink changes size" begin
+    @testset "app(io=...) does not dup fd 0 (no INPUT_IO, no EINVAL)" begin
+        # The wart the maintainer flagged: app() dup'd fd 0 unconditionally,
+        # and Base.TTY(RawFD(dup(0))) throws EINVAL when fd 0 is not a tty --
+        # the headless case. With `io` set, the dup is skipped, so this runs
+        # with NOTHING pre-set.
+        @kwdef mutable struct _Q <: T.Model; n::Int = 0; end
+        T.should_quit(m::_Q) = m.n >= 2
+        T.view(m::_Q, f::T.Frame) = (m.n += 1; render(Block(title = "q"), f.area, f.buffer))
+        @assert T.INPUT_IO[] === nothing
+        sink = IOBuffer()
+        @test app(_Q(); io = sink, tty_size = (rows = 5, cols = 20)) === nothing
+    end
+
+    @testset "set_size! is how an injected sink changes size" begin
         # No tty to probe and no SIGWINCH to catch: the caller who owns the
         # sink is the only one who knows, so it has to say.
         sink = IOBuffer()
         T.with_terminal(; io = sink, tty_size = (rows = 7, cols = 33)) do t
-            @test resize!(t, (rows = 12, cols = 50)) == true
+            @test T.set_size!(t, (rows = 12, cols = 50)) == true
             @test t.size == Rect(1, 1, 50, 12)
             T.draw!(t) do f
                 @test f.area.width == 50
                 @test f.area.height == 12
             end
-            # Unchanged size is not a resize -- draw! keys its clear off this.
-            @test resize!(t, (rows = 12, cols = 50)) == false
+            # Unchanged size is not a resize.
+            @test T.set_size!(t, (rows = 12, cols = 50)) == false
+        end
+    end
+
+    @testset "set_size! arms a one-shot clear so a shrink wipes stale glyphs" begin
+        # Issue: check_resize! is hard-wired false for external_size, and
+        # draw! keys CLEAR_SCREEN off its return -- so an external resize
+        # never cleared, leaving glyphs outside a shrunk region on the
+        # receiver. set_size! now arms a one-shot clear that check_resize!
+        # reports once.
+        sink = IOBuffer()
+        T.with_terminal(; io = sink, tty_size = (rows = 20, cols = 60)) do t
+            T.draw!(t) do f; render(Block(title = "big"), f.area, f.buffer); end
+            take!(sink)                              # drain the first frame
+            @test T.set_size!(t, (rows = 8, cols = 30)) == true
+            @test t.pending_clear == true            # armed
+            T.draw!(t) do f; render(Block(title = "small"), f.area, f.buffer); end
+            @test t.pending_clear == false           # consumed
+            @test occursin("\e[2J", String(take!(sink)))   # CLEAR_SCREEN emitted
+            # ...and it does NOT clear again on the next, unchanged frame.
+            T.draw!(t) do f; render(Block(title = "small"), f.area, f.buffer); end
+            @test !occursin("\e[2J", String(take!(sink)))
         end
     end
 end

--- a/test/test_injectable_io.jl
+++ b/test/test_injectable_io.jl
@@ -138,6 +138,41 @@
         end
     end
 
+    @testset "an explicit input source wins over a host's INPUT_IO" begin
+        # A host that installed its own INPUT_IO used to silently win over an
+        # explicit `input`, so the app read from the host's source -- or, if
+        # that source was empty, took no keys at all with nothing to explain
+        # why. The kwarg names the source, so the kwarg wins; the host's
+        # source is put back on exit.
+        @kwdef mutable struct _In <: T.Model; n::Int = 0; end
+        T.should_quit(m::_In) = m.n >= 2
+        T.view(m::_In, f::T.Frame) = (m.n += 1; render(Block(title = "in"), f.area, f.buffer))
+
+        host_source = IOBuffer()
+        mine = IOBuffer()
+        T.INPUT_IO[] = host_source
+        try
+            seen = Ref{Any}(:unset)
+            app(_In(); io = IOBuffer(), tty_size = (rows = 5, cols = 20),
+                input = mine, on_terminal = _ -> (seen[] = T.INPUT_IO[]))
+            @test seen[] === mine              # the kwarg won while running
+            @test T.INPUT_IO[] === host_source # ...and the host got its own back
+        finally
+            T.INPUT_IO[] = nothing
+        end
+    end
+
+    @testset "the default path still clears INPUT_IO on exit" begin
+        # Unchanged behaviour for the ordinary case: nothing installed going in,
+        # nothing left installed coming out.
+        @kwdef mutable struct _Def <: T.Model; n::Int = 0; end
+        T.should_quit(m::_Def) = m.n >= 2
+        T.view(m::_Def, f::T.Frame) = (m.n += 1; render(Block(title = "d"), f.area, f.buffer))
+        @test T.INPUT_IO[] === nothing
+        app(_Def(); io = IOBuffer(), tty_size = (rows = 5, cols = 20), input = IOBuffer())
+        @test T.INPUT_IO[] === nothing
+    end
+
     @testset "teardown does not touch the host's stdin" begin
         # enter_tui! skips raw mode on this process's stdin for an injected sink,
         # so leave_tui! must skip restoring it. The two used to disagree:

--- a/tools/io_sink_demo.jl
+++ b/tools/io_sink_demo.jl
@@ -1,0 +1,141 @@
+# ═══════════════════════════════════════════════════════════════════════
+# io_sink_demo.jl ── manual harness for `app(io = ...)` (PR #39)
+#
+# Runs a Tachikoma app whose frames go into a TCP socket instead of a
+# terminal, and whose keystrokes come back off that same socket. Nothing
+# in this process is attached to a tty, which is the whole claim under
+# test. A second port accepts resize messages so `set_size!` can be
+# exercised without a SIGWINCH.
+#
+# ── Run it ────────────────────────────────────────────────────────────
+#
+#   Terminal A (ideally a live Julia REPL — see "what to check" below):
+#       julia --project=. -e 'include("tools/io_sink_demo.jl"); serve()'
+#
+#   Terminal B — the "remote display". nc is the whole client: it pipes
+#   your keystrokes into the socket and the frames back out to the screen.
+#       stty raw -echo; nc localhost 9000; stty sane
+#
+#   Terminal C — declare a new viewport size at any time:
+#       echo "30 100" | nc localhost 9001
+#
+#   Press q or Esc in terminal B to quit the app.
+#
+# ── What to check ─────────────────────────────────────────────────────
+#
+#  1. Frames appear in B, driven by a process with no terminal of its own.
+#  2. Keys typed in B reach the app (the counter moves, q quits).
+#  3. A resize from C reflows the UI *and* wipes the old frame — no stale
+#     glyphs outside the new, smaller region.
+#  4. THE REGRESSION THIS PR NEARLY SHIPPED: run serve() from a live REPL
+#     in A. After the app exits, A's REPL must still be usable — arrow
+#     keys, history, the works. Before the teardown fix, leave_tui! called
+#     set_raw_mode!(false) on A's stdin even though setup never touched
+#     it, dropping the REPL out of raw mode.
+#  5. Nothing the app prints leaks into A's stdout: the injected path
+#     deliberately does not redirect the process's streams.
+# ═══════════════════════════════════════════════════════════════════════
+
+using Tachikoma
+using Sockets
+
+const T = Tachikoma
+
+@kwdef mutable struct SinkModel <: Tachikoma.Model
+    quit::Bool = false
+    tick::Int = 0
+    keys::Vector{String} = String[]
+    resizes::Int = 0
+    size_note::String = ""
+end
+
+Tachikoma.should_quit(m::SinkModel) = m.quit
+
+function Tachikoma.update!(m::SinkModel, evt::KeyEvent)
+    label = evt.key == :char ? string(evt.char) : string(evt.key)
+    pushfirst!(m.keys, label)
+    length(m.keys) > 8 && pop!(m.keys)
+    evt.key == :escape && (m.quit = true)
+    evt.key == :char && evt.char == 'q' && (m.quit = true)
+end
+
+function Tachikoma.view(m::SinkModel, f::Frame)
+    m.tick += 1
+    outer = Block(title = " rendering into a socket ", box = BOX_ROUNDED,
+                  border_style = tstyle(:border_focus))
+    inner = render(outer, f.area, f.buffer)
+
+    lines = [
+        "frame        $(m.tick)",
+        "viewport     $(f.area.width)×$(f.area.height)",
+        "resizes      $(m.resizes)  $(m.size_note)",
+        "",
+        "recent keys  " * (isempty(m.keys) ? "(none yet)" : join(m.keys, " ")),
+        "",
+        "This process owns no terminal. Frames are bytes on a socket;",
+        "keystrokes arrive the same way. Send a resize with:",
+        "    echo \"30 100\" | nc localhost 9001",
+        "",
+        "q or Esc to quit.",
+    ]
+    render(Paragraph(join(lines, "\n"), style = tstyle(:text)), inner, f.buffer)
+end
+
+"""
+    serve(; port = 9000, rows = 24, cols = 80)
+
+Wait for a display client on `port`, then run the app with its frames and
+input bound to that socket. Resize messages ("<rows> <cols>\\n") are read
+from `port + 1`.
+"""
+function serve(; port::Int = 9000, rows::Int = 24, cols::Int = 80)
+    server = listen(port)
+    ctl_server = listen(port + 1)
+    @info "io_sink_demo: waiting for a display client" connect = "stty raw -echo; nc localhost $port; stty sane" resize = "echo \"30 100\" | nc localhost $(port + 1)"
+    sock = accept(server)
+    @info "io_sink_demo: client attached — frames now going to the socket"
+
+    model = SinkModel()
+    term = Ref{Union{Tachikoma.Terminal,Nothing}}(nothing)
+
+    # Resize listener. A socket has no SIGWINCH, so the caller that owns the
+    # sink is the only one who can say how big the viewport is — that is
+    # exactly what set_size! exists for.
+    ctl = @async begin
+        while !model.quit
+            c = try accept(ctl_server) catch; break end
+            @async begin
+                for line in eachline(c)
+                    parts = split(strip(line))
+                    length(parts) == 2 || continue
+                    r, cl = tryparse(Int, parts[1]), tryparse(Int, parts[2])
+                    (r === nothing || cl === nothing) && continue
+                    t = term[]
+                    t === nothing && continue
+                    if Tachikoma.set_size!(t, (rows = r, cols = cl))
+                        model.resizes += 1
+                        model.size_note = "← last: $(r)×$(cl)"
+                    end
+                end
+                close(c)
+            end
+        end
+    end
+
+    try
+        app(model;
+            io = sock,                       # frames go here
+            input = sock,                    # ...and keystrokes come back off it
+            tty_size = (rows = rows, cols = cols),
+            on_terminal = t -> (term[] = t), # the handle set_size! needs
+            fps = 30)
+    finally
+        model.quit = true
+        for s in (sock, server, ctl_server)
+            try close(s) catch end
+        end
+    end
+    @info "io_sink_demo: app exited" frames = model.tick resizes = model.resizes
+    @info "Now check this REPL is still usable — arrow keys, history, Ctrl-R."
+    return model
+end


### PR DESCRIPTION
## What

Adds an `io` keyword to `with_terminal` and `app`, letting a Tachikoma app
render into a caller-supplied `IO` sink — a socket, a pipe, an `IOBuffer` —
instead of only a terminal this process is attached to.

```julia
sink = IOBuffer()
app(model; io = sink, tty_size = (rows = 24, cols = 80))
```

## Why

`Terminal` is already IO-polymorphic — every write goes through `t.io` — but
`with_terminal` could only ever *build* that sink from a path, so the only
reachable sinks were `/dev/tty`, a tty path, or `stdout`. There was no way to
hand it a sink you already hold. That makes it awkward to drive a Tachikoma UI
from anything that isn't a local terminal: streaming frames to a WebSocket,
piping to another process, or capturing to a buffer for a test.

This is a small extension of the existing `remote_tty` machinery rather than a
new path: an injected sink is a remote terminal in every respect that matters —
it isn't the terminal this process owns — so it reuses that mode's handling
(no raw mode on the process's own stdin, none of the kitty/graphics probes that
would write to a terminal the frames aren't going to).

## Two things an injected sink can't do that a tty can

- **It can't be probed for its size.** So `tty_size` is required alongside `io`,
  and `check_resize!` must not probe: it was calling `terminal_size()` whenever
  `remote_tty_path` was `nothing` — which is the injected case — and under an
  app's own stdout capture that reaches a pipe and returns the 80×24 default,
  silently resizing every frame. A new `external_size` flag stops that.
- **It has no SIGWINCH.** So a new `set_size!(::Terminal, sz)` lets the caller
  — a socket that just received a resize frame, say — declare the new size.

The caller's `io` is the caller's to close: a socket outlives any one app, so
`with_terminal` never closes a sink it didn't open.

## Compatibility

Purely additive. The default path (no `io`) is unchanged. The pre-existing
13-field positional `Terminal` constructor is preserved for callers that predate
the new `external_size` field.

## Tests

`test/test_injectable_io.jl` (new, wired into `runtests.jl`) covers the injected
path end to end, including a real `Model` driven through `app()` into an
`IOBuffer` with no terminal involved, plus the size-required guard, the
resize path, and the don't-close-the-caller's-sink guarantee. Full suite green
locally (5178 passed, 0 failures; +19 over baseline).

---

*Developed with AI assistance.*

---

### Maintainer follow-ups (kahliburke)

- `leave_tui!` branched on `remote_tty_path`, which an injected `io` leaves
  `nothing`, so teardown called `set_raw_mode!(false)` on a stdin that
  `enter_tui!` had deliberately not touched — dropping an embedding REPL out of
  raw mode on every app exit. Both paths now derive "not our terminal" from one
  `_is_remote_terminal` predicate so they cannot drift again.
- An explicit `input=` now takes precedence over an `INPUT_IO` a host already
  installed, and that previous source is restored on exit. It was silently
  ignored, leaving the app taking no keys with nothing to explain why.
- Restored `demos/TachikomaDemos/Project.toml` `[sources]` to `../..`; running
  the test suite rewrites it to an absolute local path, which had been committed.
- Added `tools/io_sink_demo.jl`, a manual harness (frames and input over a
  socket, `set_size!` over a second port, `nc` as the client). It covers the one
  thing no automated test can: `set_raw_mode!` is a no-op when stdin isn't a
  tty, so the teardown regression is invisible headless.
- Merged `main`.
